### PR TITLE
Implement ability to use multiple projects

### DIFF
--- a/config/conductor.php
+++ b/config/conductor.php
@@ -1,6 +1,42 @@
 <?php
 
 return [
-    'base_uri' => env('CONDUCTOR_URL'),
-    'bearer_token' => env('CONDUCTOR_TOKEN'),
+    /*
+    |--------------------------------------------------------------------------
+    | Conductor API base URL
+    |--------------------------------------------------------------------------
+    |
+    | This URL is used to send HTTP requests to the Condcutor API.
+    |
+    */
+    'base_url' => env('CONDUCTOR_URL'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Project
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default project that will be used by the SDK.
+    | This project is utilized if another isn't explicitly
+    | specified when using the Condcutor class.
+    |
+    */
+    'default_project' => env('CONDUCTOR_PROJECT'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Conductor Projects
+    |--------------------------------------------------------------------------
+    |
+    | Below are all of the projects used by your application to interact with
+    | Condcutor. An example project is provided below.
+    | You can find project details in your Condcutor dashboard.
+    |
+    */
+    'projects' => [
+        'My Project' => [
+            'name' => 'My Project',
+            'bearer_token' => env('CONDUCTOR_MY_PROJECT_TOKEN'),
+        ],
+    ],
 ];

--- a/src/Client/Actions/FetchMany.php
+++ b/src/Client/Actions/FetchMany.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Conductor\Client\Actions;
+
+trait FetchMany
+{
+    /**
+     * Extension of \Swis\JsonApi\Client\Actions\FetchMany
+     * See https://github.com/swisnl/json-api-client/issues/102
+     *
+     *
+     * @return \Swis\JsonApi\Client\Interfaces\DocumentInterface
+     */
+    public function all(array $parameters = [], array $headers = [])
+    {
+        return $this->getClient()->get($this->getEndpoint().'?'.http_build_query($parameters), $headers);
+    }
+}

--- a/src/Repositories/FeatureRepository.php
+++ b/src/Repositories/FeatureRepository.php
@@ -2,14 +2,12 @@
 
 namespace Rapkis\Conductor\Repositories;
 
-use Swis\JsonApi\Client\Actions\FetchMany;
-use Swis\JsonApi\Client\Actions\FetchOne;
+use Rapkis\Conductor\Client\Actions\FetchMany;
 use Swis\JsonApi\Client\BaseRepository;
 
 class FeatureRepository extends BaseRepository
 {
     use FetchMany;
-    use FetchOne;
 
     protected $endpoint = 'features';
 }

--- a/src/Repositories/FunnelRepository.php
+++ b/src/Repositories/FunnelRepository.php
@@ -2,14 +2,12 @@
 
 namespace Rapkis\Conductor\Repositories;
 
-use Swis\JsonApi\Client\Actions\FetchMany;
-use Swis\JsonApi\Client\Actions\FetchOne;
+use Rapkis\Conductor\Client\Actions\FetchMany;
 use Swis\JsonApi\Client\BaseRepository;
 
 class FunnelRepository extends BaseRepository
 {
     use FetchMany;
-    use FetchOne;
 
     protected $endpoint = 'funnels';
 }

--- a/tests/Client/Actions/FetchManyTest.php
+++ b/tests/Client/Actions/FetchManyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Swis\JsonApi\Client\Interfaces\DocumentClientInterface;
+
+it('passes headers from to underlying document client', function () {
+    $documentClient = $this->createMock(DocumentClientInterface::class);
+    class TestRepository
+    {
+        use \Rapkis\Conductor\Client\Actions\FetchMany;
+
+        public function __construct(protected DocumentClientInterface $client)
+        {
+        }
+
+        public function getClient()
+        {
+            return $this->client;
+        }
+
+        public function getEndpoint()
+        {
+            return 'example.com';
+        }
+    }
+
+    $repository = new TestRepository($documentClient);
+
+    $documentClient->expects($this->once())
+        ->method('get')
+        ->with(
+            'example.com?',
+            ['Test-Header' => 'Foo-Bar'],
+        );
+
+    $repository->all([], ['Test-Header' => 'Foo-Bar']);
+});

--- a/tests/ConductorServiceProviderTest.php
+++ b/tests/ConductorServiceProviderTest.php
@@ -4,25 +4,18 @@ use Rapkis\Conductor\Resources\Feature;
 use Rapkis\Conductor\Resources\FeatureSet;
 use Rapkis\Conductor\Resources\Funnel;
 use Rapkis\Conductor\Resources\Metric;
-use Swis\JsonApi\Client\Client;
 use Swis\JsonApi\Client\Interfaces\ClientInterface;
 use Swis\JsonApi\Client\Interfaces\ItemInterface;
 use Swis\JsonApi\Client\Interfaces\TypeMapperInterface;
 
-it('adds a missing slash for the api uri', function () {
-    config(['conductor.base_uri' => 'foo/bar']);
+it('adds a missing slash for the api url', function () {
+    config(['conductor.base_url' => 'foo/bar']);
     $client = app(ClientInterface::class);
     expect($client->getBaseUri())->toBe('foo/bar/');
 
-    config(['conductor.base_uri' => 'foo/bar/']);
+    config(['conductor.base_url' => 'foo/bar/']);
     $client = app(ClientInterface::class);
     expect($client->getBaseUri())->toBe('foo/bar/');
-});
-
-it('sets a default bearer token', function () {
-    /** @var Client $client */
-    $client = app(ClientInterface::class);
-    expect($client->getDefaultHeaders())->toHaveKey('Authorization');
 });
 
 it('maps resources to ItemMapper', function () {


### PR DESCRIPTION
- Refactored the config file to have a 'projects' array. A project can have a name and a bearer_token
- Also rename the 'base_uri' config variable name to 'base_url'
- No longer bind default authorization headers in ConductorServiceProvider.php. Instead, pass the whole config to the Conductor.php class
- The Conductor.php class accepts a config. It parses all available projects and keeps track of the "current" project. It defines the authorization header during runtime before sending requests to the API via repositories
- Replaced usages of Swis\JsonApi\Client\Actions\FetchMany with a similar first-party trait instead. The new trait accepts a second argument for the headers
- Remove usages of a currently unused trait FetchOne