### PR TITLE
Implement API endpoint to record metrics

### DIFF
--- a/src/ConductorServiceProvider.php
+++ b/src/ConductorServiceProvider.php
@@ -7,6 +7,7 @@ use Rapkis\Conductor\Resources\Feature;
 use Rapkis\Conductor\Resources\FeatureSet;
 use Rapkis\Conductor\Resources\Funnel;
 use Rapkis\Conductor\Resources\Metric;
+use Rapkis\Conductor\Resources\MetricTimeSeries;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Swis\JsonApi\Client\Client;
@@ -27,6 +28,7 @@ class ConductorServiceProvider extends PackageServiceProvider
         Funnel::class,
         FeatureSet::class,
         Metric::class,
+        MetricTimeSeries::class,
     ];
 
     public function configurePackage(Package $package): void

--- a/src/EnteredFunnel.php
+++ b/src/EnteredFunnel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rapkis\Conductor;
+
+use Rapkis\Conductor\Resources\FeatureSet;
+use Rapkis\Conductor\Resources\Funnel;
+
+class EnteredFunnel
+{
+    public function __construct(public readonly Funnel $funnel, public readonly FeatureSet $set)
+    {
+    }
+}

--- a/src/Jobs/RecordMetricForEnteredFunnelJob.php
+++ b/src/Jobs/RecordMetricForEnteredFunnelJob.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rapkis\Conductor\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Rapkis\Conductor\Conductor;
+use Rapkis\Conductor\EnteredFunnel;
+use Rapkis\Conductor\Resources\Metric;
+
+class RecordMetricForEnteredFunnelJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+
+    public function __construct(
+        public readonly EnteredFunnel $entry,
+        public readonly string $metric,
+        public readonly int $value,
+        public readonly ?\DateTimeInterface $dateTime = null,
+    ) {
+    }
+
+    public function handle(Conductor $conductor): void
+    {
+        /** @var Metric|null $metric */
+        $metric = $this->entry->funnel->metrics->firstWhere(Metric::NAME, $this->metric);
+        if (! $metric) {
+            return;
+        }
+
+        $success = $conductor->recordMetric($metric, $this->entry->set, $this->value, $this->dateTime);
+
+        if (! $success) {
+            $this->fail('Conductor failed to record a metric');
+        }
+    }
+}

--- a/src/Repositories/MetricTimeSeriesRepository.php
+++ b/src/Repositories/MetricTimeSeriesRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rapkis\Conductor\Repositories;
+
+use Swis\JsonApi\Client\Actions\Create;
+use Swis\JsonApi\Client\BaseRepository;
+
+class MetricTimeSeriesRepository extends BaseRepository
+{
+    use Create;
+
+    protected $endpoint = 'metric-time-series';
+}

--- a/src/Resources/MetricTimeSeries.php
+++ b/src/Resources/MetricTimeSeries.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rapkis\Conductor\Resources;
+
+use Rapkis\Conductor\Contracts\Resources\Resource;
+use Swis\JsonApi\Client\Interfaces\ManyRelationInterface;
+use Swis\JsonApi\Client\Item;
+use Swis\JsonApi\Client\Relations\HasOneRelation;
+
+/**
+ * @property string $metric
+ * @property string $featureSet
+ * @property string $value
+ * @property string $timeSegment
+ */
+class MetricTimeSeries extends Item implements Resource
+{
+    public const METRIC = 'metric';
+
+    public const FEATURE_SET = 'featureSet';
+
+    public const VALUE = 'value';
+
+    public const TIME_SEGMENT = 'time_segment';
+
+    public const TYPE = 'metric-time-series';
+
+    protected $type = self::TYPE;
+
+    protected $availableRelations = [
+        self::METRIC,
+        self::FEATURE_SET,
+    ];
+
+    protected $fillable = [
+        self::METRIC,
+        self::FEATURE_SET,
+        self::VALUE,
+        self::TIME_SEGMENT,
+    ];
+
+    public function featureSet(): ManyRelationInterface|HasOneRelation
+    {
+        return $this->hasOne(FeatureSet::class, self::FEATURE_SET);
+    }
+
+    public function metric(): ManyRelationInterface|HasOneRelation
+    {
+        return $this->hasOne(Metric::class);
+    }
+}

--- a/tests/Jobs/RecordMetricForEnteredFunnelJobTest.php
+++ b/tests/Jobs/RecordMetricForEnteredFunnelJobTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Rapkis\Conductor\Conductor;
+use Rapkis\Conductor\EnteredFunnel;
+use Rapkis\Conductor\Jobs\RecordMetricForEnteredFunnelJob;
+use Rapkis\Conductor\Resources\FeatureSet;
+use Rapkis\Conductor\Resources\Funnel;
+use Rapkis\Conductor\Resources\Metric;
+use Swis\JsonApi\Client\ItemHydrator;
+
+it('records the metric for an entered funnel', function () {
+    $hydrator = $this->app->make(ItemHydrator::class);
+    $funnel = $hydrator->hydrate(new Funnel(), [
+        'featureSets' => [
+            [
+                'id' => '5678',
+                FeatureSet::FEATURES => ['test' => 'foo', 'bar' => ['baz']],
+            ],
+        ],
+        'metrics' => [
+            ['id' => '5678', Metric::NAME => 'conversion'],
+        ],
+    ]);
+    $entry = new EnteredFunnel($funnel, $funnel->featureSets->first());
+    $job = new RecordMetricForEnteredFunnelJob($entry, 'conversion', 100);
+
+    $conductor = $this->createMock(Conductor::class);
+    $conductor->expects($this->once())->method('recordMetric')->with(
+        $funnel->metrics->first(),
+        $entry->set,
+        100,
+    );
+
+    $job->handle($conductor);
+});
+
+it('skips recording the metric if it is not tracked in the funnel', function () {
+    $hydrator = $this->app->make(ItemHydrator::class);
+    $funnel = $hydrator->hydrate(new Funnel(), [
+        'featureSets' => [
+            [
+                'id' => '5678',
+                FeatureSet::FEATURES => ['test' => 'foo', 'bar' => ['baz']],
+            ],
+        ],
+        'metrics' => [
+            ['id' => '5678', Metric::NAME => 'conversion'],
+        ],
+    ]);
+    $entry = new EnteredFunnel($funnel, $funnel->featureSets->first());
+    $job = new RecordMetricForEnteredFunnelJob($entry, 'click', 100);
+
+    $conductor = $this->createMock(Conductor::class);
+    $conductor->expects($this->never())->method('recordMetric');
+
+    $job->handle($conductor);
+});


### PR DESCRIPTION
- Create a new repository MetricTimeSeriesRepository.php
- Implement the repository in Conductor.php recordMetric(). Metrics are recorded for specific feature sets, with a value and time defined
- Created a job to record metrics asynchronously and improve the developer experience. This job, together with Conductor.php automatically handles which metrics need to be recorded for which funnels. This helps to have static metric "hooks" in an application and handle everything for the developer. Consider this use case:
You may have two funnels: funnel "foo" tracks the metric `clicks` and the funnel "bar" tracks `clicks` and `conversion`
```php
// ShowIndexPageController
$conductor->resolveFeatures();
foreach ($conductor->getEnteredFunnels() as $entry) {
    $this->dispatch(new RecordMetricForEnteredFunnelJob($entry), 'clicks', 1); // will dispatch for both and record for both
}

// MakePurchaseController
foreach ($conductor->getEnteredFunnels() as $entry) {
    $this->dispatch(new RecordMetricForEnteredFunnelJob($entry), 'conversion', 1); // will dispatch for both and record only for funnel "bar"
}
```
- Refactor tests so that they no longer depend on the constructor of Conductor.php, and use Laravel's container to pass mocked dependencies