### PR TITLE
Laravel Pennant Integration for FlagPal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "laravel",
         "flagpal-for-laravel"
     ],
-    "homepage": "https://github.com/rapkis/flagpal-for-laravel",
+    "homepage": "https://github.com/flagpal/flagpal-for-laravel",
     "license": "MIT",
     "authors": [
         {
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10.0||^11.0",
+        "illuminate/contracts": "^11.0||^12.0",
+        "laravel/pennant": "^1.17",
         "php-http/discovery": "^1.9",
         "psr/http-client": "^1.0",
         "psr/http-client-implementation": "^1.0",

--- a/src/Actions/ResolveFeaturesFromFunnel.php
+++ b/src/Actions/ResolveFeaturesFromFunnel.php
@@ -20,7 +20,7 @@ class ResolveFeaturesFromFunnel
         if (! $funnel->active || $funnel->percent < random_int(1, 100)) {
             return null;
         }
-        if (! $this->validator->passes($currentFeatures, $funnel->rules)) {
+        if (! $this->validator->passes($currentFeatures, $funnel->rules ?? [])) {
             return null;
         }
 

--- a/src/Actions/ResolveFeaturesFromFunnel.php
+++ b/src/Actions/ResolveFeaturesFromFunnel.php
@@ -12,8 +12,7 @@ class ResolveFeaturesFromFunnel
     public function __construct(
         private readonly Validator $validator,
         private readonly Raffle $raffle,
-    ) {
-    }
+    ) {}
 
     public function __invoke(Funnel $funnel, array $currentFeatures): ?FeatureSet
     {

--- a/src/Contracts/Pennant/StoresFlagPalFeatures.php
+++ b/src/Contracts/Pennant/StoresFlagPalFeatures.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rapkis\FlagPal\Contracts\Pennant;
+
+use Rapkis\FlagPal\Pennant\StatelessFeatures;
+
+interface StoresFlagPalFeatures
+{
+    public function getFlagPalFeatures(): StatelessFeatures;
+
+    public function saveFlagPalFeatures(array $features): self;
+}

--- a/src/EnteredFunnel.php
+++ b/src/EnteredFunnel.php
@@ -7,7 +7,5 @@ use Rapkis\FlagPal\Resources\Funnel;
 
 class EnteredFunnel
 {
-    public function __construct(public readonly Funnel $funnel, public readonly FeatureSet $set)
-    {
-    }
+    public function __construct(public readonly Funnel $funnel, public readonly FeatureSet $set) {}
 }

--- a/src/FlagPal.php
+++ b/src/FlagPal.php
@@ -106,7 +106,7 @@ class FlagPal
 
     public function recordMetric(Metric $metric, FeatureSet $set, int $value, ?DateTimeInterface $dateTime = null): bool
     {
-        $item = $this->itemHydrator->hydrate(new MetricTimeSeries(), [
+        $item = $this->itemHydrator->hydrate(new MetricTimeSeries, [
             MetricTimeSeries::METRIC => $metric->toJsonApiArray(),
             MetricTimeSeries::FEATURE_SET => $set->toJsonApiArray(),
             MetricTimeSeries::VALUE => $value,
@@ -135,7 +135,7 @@ class FlagPal
     public function saveActorFeatures(string $reference, array $features): Actor
     {
         /** @var Actor $actor */
-        $actor = $this->itemHydrator->hydrate(new Actor(), [
+        $actor = $this->itemHydrator->hydrate(new Actor, [
             Actor::FEATURES => $features,
         ]);
         $actor->setId($reference);
@@ -169,7 +169,7 @@ class FlagPal
         if ($document instanceof InvalidResponseDocument || $document->hasErrors()) {
             $this->log()?->error('FlagPal failed to load funnels', ['document' => $document->toArray()]);
 
-            return new Collection();
+            return new Collection;
         }
 
         $funnels = Collection::make($document->getData());

--- a/src/FlagPalServiceProvider.php
+++ b/src/FlagPalServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace Rapkis\FlagPal;
 
+use Illuminate\Contracts\Foundation\Application;
 use Rapkis\FlagPal\Contracts\Resources\Resource;
+use Rapkis\FlagPal\Pennant\FlagPalDriver;
 use Rapkis\FlagPal\Resources\Actor;
 use Rapkis\FlagPal\Resources\Feature;
 use Rapkis\FlagPal\Resources\FeatureSet;
@@ -45,6 +47,7 @@ class FlagPalServiceProvider extends PackageServiceProvider
         $this->registerSharedTypeMapper();
         $this->registerParsers();
         $this->registerClients();
+        $this->registerPennantDriver();
     }
 
     protected function registerSharedTypeMapper()
@@ -72,6 +75,15 @@ class FlagPalServiceProvider extends PackageServiceProvider
 
         $this->app->bind(ClientInterface::class, Client::class);
         $this->app->bind(DocumentClientInterface::class, DocumentClient::class);
+    }
+
+    protected function registerPennantDriver(): void
+    {
+        \Laravel\Pennant\Feature::extend(FlagPalDriver::NAME, function (Application $app, array $config) {
+            $project = $config['project'] ?? $app['config']['flagpal']['default_project'];
+
+            return new FlagPalDriver($app->make(FlagPal::class)->asProject($project));
+        });
     }
 
     public function packageBooted()

--- a/src/Jobs/RecordMetricForEnteredFunnelJob.php
+++ b/src/Jobs/RecordMetricForEnteredFunnelJob.php
@@ -21,8 +21,7 @@ class RecordMetricForEnteredFunnelJob implements ShouldQueue
         public readonly string $metric,
         public readonly int $value,
         public readonly ?\DateTimeInterface $dateTime = null,
-    ) {
-    }
+    ) {}
 
     public function handle(FlagPal $flagPal): void
     {

--- a/src/Pennant/Concerns/StoresFlagPalFeatures.php
+++ b/src/Pennant/Concerns/StoresFlagPalFeatures.php
@@ -2,8 +2,6 @@
 
 namespace Rapkis\FlagPal\Pennant\Concerns;
 
-use Laravel\Pennant\Concerns\HasFeatures;
-use Laravel\Pennant\Feature;
 use Rapkis\FlagPal\FlagPal;
 use Rapkis\FlagPal\Pennant\HasFlagPalReference;
 use Rapkis\FlagPal\Pennant\StatelessFeatures;

--- a/src/Pennant/Concerns/StoresFlagPalFeatures.php
+++ b/src/Pennant/Concerns/StoresFlagPalFeatures.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rapkis\FlagPal\Pennant\Concerns;
+
+use Laravel\Pennant\Concerns\HasFeatures;
+use Laravel\Pennant\Feature;
+use Rapkis\FlagPal\FlagPal;
+use Rapkis\FlagPal\Pennant\HasFlagPalReference;
+use Rapkis\FlagPal\Pennant\StatelessFeatures;
+
+trait StoresFlagPalFeatures
+{
+    use HasFlagPalReference;
+
+    protected FlagPal $flagPal;
+
+    public function getFlagPalFeatures(): StatelessFeatures
+    {
+        return new StatelessFeatures($this->flagPal->getActor($this->getFlagPalReference())->features ?? []);
+    }
+
+    public function saveFlagPalFeatures(array $features): self
+    {
+        $this->flagPal->saveActorFeatures($this->getFlagPalReference(), $features);
+
+        return $this;
+    }
+}

--- a/src/Pennant/Concerns/StoresFlagPalFeaturesInDatabase.php
+++ b/src/Pennant/Concerns/StoresFlagPalFeaturesInDatabase.php
@@ -32,7 +32,7 @@ trait StoresFlagPalFeaturesInDatabase
         $toDeactivate = collect($toDeactivate)->merge(collect($features)->filter(fn ($value, $name) => $value === null))->toArray();
         $toActivate = array_filter(array_diff($features, $currentFeatures));
 
-        if (!empty($toDeactivate)) {
+        if (! empty($toDeactivate)) {
             $this->newFeatureQuery()
                 ->where('scope', Feature::serializeScope($this))
                 ->whereIn('name', array_keys($toDeactivate))
@@ -58,7 +58,7 @@ trait StoresFlagPalFeaturesInDatabase
 
     protected function newFeatureQuery(): Builder
     {
-        return DB::connection(config("pennant.stores.database.connection"))
-            ->table(config("pennant.stores.database.table") ?? 'features');
+        return DB::connection(config('pennant.stores.database.connection'))
+            ->table(config('pennant.stores.database.table') ?? 'features');
     }
 }

--- a/src/Pennant/Concerns/StoresFlagPalFeaturesInDatabase.php
+++ b/src/Pennant/Concerns/StoresFlagPalFeaturesInDatabase.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Rapkis\FlagPal\Pennant\Concerns;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Laravel\Pennant\Drivers\DatabaseDriver;
+use Laravel\Pennant\Feature;
+use Rapkis\FlagPal\Pennant\StatelessFeatures;
+
+trait StoresFlagPalFeaturesInDatabase
+{
+    protected StatelessFeatures $cachedFeatures;
+
+    public function getFlagPalFeatures(): StatelessFeatures
+    {
+        if ($this->cachedFeatures ?? null) {
+            return $this->cachedFeatures;
+        }
+
+        return $this->cachedFeatures = new StatelessFeatures($this->newFeatureQuery()
+            ->where('scope', Feature::serializeScope($this))
+            ->pluck('value', 'name')
+            ->mapWithKeys(fn ($value, $key) => [$key => json_decode($value, flags: JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR)])
+            ->toArray());
+    }
+
+    public function saveFlagPalFeatures(array $features): self
+    {
+        $currentFeatures = $this->getFlagPalFeatures()->features;
+        $toDeactivate = array_diff_key($currentFeatures, $features);
+        $toDeactivate = collect($toDeactivate)->merge(collect($features)->filter(fn ($value, $name) => $value === null))->toArray();
+        $toActivate = array_filter(array_diff($features, $currentFeatures));
+
+        if (!empty($toDeactivate)) {
+            $this->newFeatureQuery()
+                ->where('scope', Feature::serializeScope($this))
+                ->whereIn('name', array_keys($toDeactivate))
+                ->delete();
+        }
+
+        $toActivate = collect($toActivate)->map(function ($value, $name) {
+            return [
+                'name' => $name,
+                'scope' => Feature::serializeScope($this),
+                'value' => json_encode($value, flags: JSON_THROW_ON_ERROR),
+                DatabaseDriver::CREATED_AT => now(),
+                DatabaseDriver::UPDATED_AT => now(),
+            ];
+        })->values();
+
+        $this->newFeatureQuery()
+            ->where('scope', Feature::serializeScope($this))
+            ->upsert($toActivate->toArray(), ['name', 'scope'], ['value', DatabaseDriver::UPDATED_AT]);
+
+        return $this;
+    }
+
+    protected function newFeatureQuery(): Builder
+    {
+        return DB::connection(config("pennant.stores.database.connection"))
+            ->table(config("pennant.stores.database.table") ?? 'features');
+    }
+}

--- a/src/Pennant/FlagPalDriver.php
+++ b/src/Pennant/FlagPalDriver.php
@@ -10,14 +10,13 @@ use Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures;
 use Rapkis\FlagPal\FlagPal;
 
 // todo features are cached in Pennant by serialized scope. We need to clear it every time before resolving features (maybe?)
-class FlagPalDriver implements Driver, DefinesFeaturesExternally
+class FlagPalDriver implements DefinesFeaturesExternally, Driver
 {
     public const NAME = 'flagpal';
 
     public function __construct(
         public readonly FlagPal $flagPal,
-    ) {
-    }
+    ) {}
 
     public function getEnteredFunnels(): array
     {
@@ -48,7 +47,7 @@ class FlagPalDriver implements Driver, DefinesFeaturesExternally
     public function get(string $feature, mixed $scope): mixed
     {
         $defined = $this->defined();
-        if (!in_array($feature, $defined)) {
+        if (! in_array($feature, $defined)) {
             return false;
         }
 
@@ -95,7 +94,7 @@ class FlagPalDriver implements Driver, DefinesFeaturesExternally
         }
     }
 
-    public function purge(array|null $features): void
+    public function purge(?array $features): void
     {
         throw new Exception('You can not purge FlagPal features! Remove them from FlagPal instead.');
     }

--- a/src/Pennant/FlagPalDriver.php
+++ b/src/Pennant/FlagPalDriver.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Rapkis\FlagPal\Pennant;
+
+use Exception;
+use Illuminate\Support\Collection;
+use Laravel\Pennant\Contracts\DefinesFeaturesExternally;
+use Laravel\Pennant\Contracts\Driver;
+use Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures;
+use Rapkis\FlagPal\FlagPal;
+
+// todo features are cached in Pennant by serialized scope. We need to clear it every time before resolving features (maybe?)
+class FlagPalDriver implements Driver, DefinesFeaturesExternally
+{
+    public const NAME = 'flagpal';
+
+    public function __construct(
+        public readonly FlagPal $flagPal,
+    ) {
+    }
+
+    public function getEnteredFunnels(): array
+    {
+        return $this->flagPal->getEnteredFunnels();
+    }
+
+    public function define(string $feature, callable $resolver): void
+    {
+        throw new Exception('FlagPal can only define features externally.');
+    }
+
+    public function defined(): array
+    {
+        return $this->definedFeaturesForScope([]);
+    }
+
+    public function getAll(array $features): array
+    {
+        $features = Collection::make($features)
+            ->map(fn ($scopes, $feature) => Collection::make($scopes)
+                ->map(fn ($scope) => $this->get($feature, $scope))
+                ->all())
+            ->all();
+
+        return $features;
+    }
+
+    public function get(string $feature, mixed $scope): mixed
+    {
+        $defined = $this->defined();
+        if (!in_array($feature, $defined)) {
+            return false;
+        }
+
+        $features = [];
+
+        if ($scope instanceof StatelessFeatures) {
+            $features = $scope->features;
+        }
+
+        if ($scope instanceof StoresFlagPalFeatures) {
+            $features = $scope->getFlagPalFeatures()->features;
+        }
+
+        // todo map values by type here?
+        $features = array_intersect_key($features, array_flip($defined));
+
+        $features = $this->flagPal->resolveFeatures($features);
+
+        if ($scope instanceof StoresFlagPalFeatures) {
+            $scope->saveFlagPalFeatures($features);
+        }
+
+        return $features[$feature] ?? null;
+    }
+
+    public function set(string $feature, mixed $scope, mixed $value): void
+    {
+        if ($scope instanceof StoresFlagPalFeatures) {
+            $scope->saveFlagPalFeatures([$feature => $value]);
+        }
+    }
+
+    public function setForAllScopes(string $feature, mixed $value): void
+    {
+        throw new Exception('You can set a feature for all scopes by creating an Experience in FlagPal');
+    }
+
+    public function delete(string $feature, mixed $scope): void
+    {
+        if ($scope instanceof StoresFlagPalFeatures) {
+            $features = $scope->getFlagPalFeatures()->features;
+            unset($features[$feature]);
+            $scope->saveFlagPalFeatures($features);
+        }
+    }
+
+    public function purge(array|null $features): void
+    {
+        throw new Exception('You can not purge FlagPal features! Remove them from FlagPal instead.');
+    }
+
+    public function definedFeaturesForScope(mixed $scope): array
+    {
+        return collect($this->flagPal->definedFeatures())->pluck('name')->toArray();
+    }
+}

--- a/src/Pennant/HasFlagPalReference.php
+++ b/src/Pennant/HasFlagPalReference.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rapkis\FlagPal\Pennant;
+
+use Laravel\Pennant\Feature;
+
+trait HasFlagPalReference
+{
+    /**
+     * Get the FlagPal reference for a model.
+     * This method is used by the FlagPalDriver to identify the scope.
+     *
+     * Uses the Laravel Pennant scope serialization by default.
+     * Override this method if you need a different reference format.
+     *
+     * @return string
+     */
+    public function getFlagPalReference(): string
+    {
+        return Feature::serializeScope($this);
+    }
+}

--- a/src/Pennant/HasFlagPalReference.php
+++ b/src/Pennant/HasFlagPalReference.php
@@ -12,8 +12,6 @@ trait HasFlagPalReference
      *
      * Uses the Laravel Pennant scope serialization by default.
      * Override this method if you need a different reference format.
-     *
-     * @return string
      */
     public function getFlagPalReference(): string
     {

--- a/src/Pennant/StatelessFeatures.php
+++ b/src/Pennant/StatelessFeatures.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\FlagPal\Pennant;
+
+use Laravel\Pennant\Contracts\FeatureScopeSerializeable;
+
+class StatelessFeatures implements FeatureScopeSerializeable
+{
+    public function __construct(
+        public readonly array $features,
+    ) {
+    }
+    public function featureScopeSerialize(): string
+    {
+        return json_encode($this->features);
+    }
+}

--- a/src/Pennant/StatelessFeatures.php
+++ b/src/Pennant/StatelessFeatures.php
@@ -10,8 +10,8 @@ class StatelessFeatures implements FeatureScopeSerializeable
 {
     public function __construct(
         public readonly array $features,
-    ) {
-    }
+    ) {}
+
     public function featureScopeSerialize(): string
     {
         return json_encode($this->features);

--- a/src/Validation/RuleFactory.php
+++ b/src/Validation/RuleFactory.php
@@ -14,6 +14,6 @@ class RuleFactory
             throw new \InvalidArgumentException("Rule \"{$name}\" does not exist");
         }
 
-        return new $className();
+        return new $className;
     }
 }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -11,8 +11,7 @@ class Validator
     public function __construct(
         public readonly Factory $validator,
         public readonly RuleFactory $ruleFactory,
-    ) {
-    }
+    ) {}
 
     public function passes(array $features, array $rules): bool
     {

--- a/tests/Actions/ResolveFeaturesFromFunnelTest.php
+++ b/tests/Actions/ResolveFeaturesFromFunnelTest.php
@@ -7,7 +7,7 @@ use Rapkis\FlagPal\Support\Raffle;
 use Rapkis\FlagPal\Validation\Validator;
 use Swis\JsonApi\Client\ItemHydrator;
 
-it('resolves a feature set from funnel', function () {
+it('resolves a feature set from funnel', function (?array $rules) {
     /** @var ItemHydrator $hydrator */
     $hydrator = app(ItemHydrator::class);
 
@@ -15,7 +15,7 @@ it('resolves a feature set from funnel', function () {
     $funnel = $hydrator->hydrate(new Funnel(), [
         Funnel::ACTIVE => true,
         Funnel::PERCENT => 100,
-        Funnel::RULES => [],
+        Funnel::RULES => $rules,
         'featureSets' => [
             [
                 'id' => '8888',
@@ -41,7 +41,10 @@ it('resolves a feature set from funnel', function () {
 
     expect($set)->toBeInstanceOf(FeatureSet::class)
         ->and($set->getId())->toBe('9999');
-});
+})->with([
+    [[]],
+    [null]
+]);
 
 it('skips funnel if disabled', function () {
     $funnel = new Funnel();

--- a/tests/Actions/ResolveFeaturesFromFunnelTest.php
+++ b/tests/Actions/ResolveFeaturesFromFunnelTest.php
@@ -12,7 +12,7 @@ it('resolves a feature set from funnel', function (?array $rules) {
     $hydrator = app(ItemHydrator::class);
 
     /** @var Funnel $funnel */
-    $funnel = $hydrator->hydrate(new Funnel(), [
+    $funnel = $hydrator->hydrate(new Funnel, [
         Funnel::ACTIVE => true,
         Funnel::PERCENT => 100,
         Funnel::RULES => $rules,
@@ -43,11 +43,11 @@ it('resolves a feature set from funnel', function (?array $rules) {
         ->and($set->getId())->toBe('9999');
 })->with([
     [[]],
-    [null]
+    [null],
 ]);
 
 it('skips funnel if disabled', function () {
-    $funnel = new Funnel();
+    $funnel = new Funnel;
     $funnel2 = new Funnel([Funnel::ACTIVE => false]);
 
     $resolver = app(ResolveFeaturesFromFunnel::class);
@@ -77,7 +77,7 @@ it('skips funnel if validation fails', function () {
     $validator = $this->createStub(Validator::class);
     $validator->method('passes')->willReturn(false);
 
-    $resolver = new ResolveFeaturesFromFunnel($validator, new Raffle());
+    $resolver = new ResolveFeaturesFromFunnel($validator, new Raffle);
 
     expect($resolver($funnel, []))->toBeNull();
 });

--- a/tests/FlagPalServiceProviderTest.php
+++ b/tests/FlagPalServiceProviderTest.php
@@ -34,3 +34,31 @@ it('maps resources to ItemMapper', function () {
         expect($mapper->hasMapping($item->getType()))->toBeTrue();
     }
 });
+
+it('registers the pennant driver', function () {
+    config([
+        'flagpal.projects' => [
+            'foo' => [],
+            'bar' => [],
+        ],
+        'flagpal.default_project' => 'foo',
+        'pennant.stores' => [
+            'foo' => [
+                'driver' => 'flagpal',
+                'project' => null
+            ],
+
+            'bar' => [
+                'driver' => 'flagpal',
+                'project' => 'Bar',
+            ],
+        ]
+    ]);
+
+    /** @var \Rapkis\FlagPal\Pennant\FlagPalDriver $driver */
+    $driver = \Laravel\Pennant\Feature::store('foo')->getDriver();
+    expect($driver->flagPal->getProject())->toBe('foo');
+
+    $driver = \Laravel\Pennant\Feature::store('bar')->getDriver();
+    expect($driver->flagPal->getProject())->toBe('Bar');
+});

--- a/tests/FlagPalServiceProviderTest.php
+++ b/tests/FlagPalServiceProviderTest.php
@@ -45,14 +45,14 @@ it('registers the pennant driver', function () {
         'pennant.stores' => [
             'foo' => [
                 'driver' => 'flagpal',
-                'project' => null
+                'project' => null,
             ],
 
             'bar' => [
                 'driver' => 'flagpal',
                 'project' => 'Bar',
             ],
-        ]
+        ],
     ]);
 
     /** @var \Rapkis\FlagPal\Pennant\FlagPalDriver $driver */

--- a/tests/FlagPalTest.php
+++ b/tests/FlagPalTest.php
@@ -30,7 +30,7 @@ it('loads funnels from API', function () {
     $flagPal = $this->app->make(FlagPal::class, ['funnelRepository' => $funnelRepository]);
 
     $document = $this->createStub(DocumentInterface::class);
-    $document->method('getData')->willReturn(new Collection());
+    $document->method('getData')->willReturn(new Collection);
 
     $funnelRepository->expects($this->once())
         ->method('all')
@@ -59,7 +59,7 @@ it('handles API errors', function (?string $logDriver) {
     ]);
 
     $errors = new ErrorCollection([new \Swis\JsonApi\Client\Error('123', null, '401', '401')]);
-    $document = new Document();
+    $document = new Document;
     $document->setErrors($errors);
 
     $funnelRepository->method('all')
@@ -94,7 +94,7 @@ it('caches funnels', function (?string $driver) {
     $flagPal = $this->app->make(FlagPal::class, ['funnelRepository' => $funnelRepository]);
 
     $document = $this->createStub(DocumentInterface::class);
-    $document->method('getData')->willReturn(new Collection());
+    $document->method('getData')->willReturn(new Collection);
 
     $funnelRepository->expects($this->once())
         ->method('all')
@@ -141,7 +141,7 @@ it('resolves features from all funnels', function () {
     $hydrator = app(ItemHydrator::class);
 
     /** @var Funnel $funnel */
-    $funnel = $hydrator->hydrate(new Funnel(), [
+    $funnel = $hydrator->hydrate(new Funnel, [
         Funnel::ACTIVE => true,
         Funnel::PERCENT => 100,
         Funnel::RULES => [],
@@ -187,7 +187,7 @@ it('skips funnel if no set was resolved', function () {
     $hydrator = app(ItemHydrator::class);
 
     /** @var Funnel $funnel */
-    $funnel = $hydrator->hydrate(new Funnel(), [
+    $funnel = $hydrator->hydrate(new Funnel, [
         Funnel::ACTIVE => true,
         Funnel::PERCENT => 100,
         Funnel::RULES => [['feature' => 'current', 'rule' => 'equal', 'value' => null]],
@@ -228,7 +228,7 @@ it('switches between projects', function () {
     $flagPal = $this->app->make(FlagPal::class, ['funnelRepository' => $funnelRepository]);
 
     $document = $this->createStub(DocumentInterface::class);
-    $document->method('getData')->willReturn(new Collection());
+    $document->method('getData')->willReturn(new Collection);
 
     $parameters = [
         'filter' => ['active' => true],
@@ -251,15 +251,15 @@ it('records a metric', function (bool $hasErrors) {
     /** @var FlagPal $flagPal */
     $flagPal = $this->app->make(FlagPal::class, ['metricTimeSeriesRepository' => $metricTimeSeriesRepository]);
 
-    $document = new Document();
+    $document = new Document;
     if ($hasErrors) {
         $errors = new ErrorCollection([new \Swis\JsonApi\Client\Error('123', null, '401', '401')]);
         $document->setErrors($errors);
     }
 
-    $metric = (new Metric())->setId('123');
-    $set = (new FeatureSet())->setId('123');
-    $payload = app(ItemHydrator::class)->hydrate(new MetricTimeSeries(), [
+    $metric = (new Metric)->setId('123');
+    $set = (new FeatureSet)->setId('123');
+    $payload = app(ItemHydrator::class)->hydrate(new MetricTimeSeries, [
         MetricTimeSeries::METRIC => $metric->toJsonApiArray(),
         MetricTimeSeries::FEATURE_SET => $set->toJsonApiArray(),
         MetricTimeSeries::VALUE => 100,
@@ -296,8 +296,8 @@ it('gets actor by reference', function (DocumentInterface $repositoryResult, ?Ac
 
     expect($flagPal->getActor('test_actor'))->toEqual($expected);
 })->with([
-    [(new Document())->setData(new Actor()), new Actor()],
-    [new Document(), null],
+    [(new Document)->setData(new Actor), new Actor],
+    [new Document, null],
 ]);
 
 it('saves an actor', function () {
@@ -306,12 +306,12 @@ it('saves an actor', function () {
     /** @var FlagPal $flagPal */
     $flagPal = $this->app->make(FlagPal::class, ['actorRepository' => $actorRepository]);
 
-    $actor = new Actor();
+    $actor = new Actor;
 
     $actorRepository->expects($this->once())
         ->method('create')
         ->with($actor)
-        ->willReturn((new Document())->setData($actor));
+        ->willReturn((new Document)->setData($actor));
 
     expect($flagPal->saveActor($actor))->toBe($actor);
 });
@@ -324,13 +324,13 @@ it('saves features for an actor', function () {
 
     /** @var ItemHydrator $itemHydrator */
     $itemHydrator = app(ItemHydrator::class);
-    $actor = $itemHydrator->hydrate(new Actor(), [Actor::FEATURES => ['foo_feature' => 'foo_value']]);
+    $actor = $itemHydrator->hydrate(new Actor, [Actor::FEATURES => ['foo_feature' => 'foo_value']]);
     $actor->setId('test_actor');
 
     $actorRepository->expects($this->once())
         ->method('create')
         ->with($actor)
-        ->willReturn((new Document())->setData($actor));
+        ->willReturn((new Document)->setData($actor));
 
     expect($flagPal->saveActorFeatures('test_actor', ['foo_feature' => 'foo_value']))->toBe($actor);
 });
@@ -449,7 +449,7 @@ it('handles API errors when retrieving defined features', function (?string $log
     ]);
 
     $errors = new ErrorCollection([new \Swis\JsonApi\Client\Error('123', null, '401', '401')]);
-    $document = new Document();
+    $document = new Document;
     $document->setErrors($errors);
 
     $featureRepository->method('all')

--- a/tests/FunnelTest.php
+++ b/tests/FunnelTest.php
@@ -8,7 +8,7 @@ it('has feature sets as a relation', function () {
     $hydrator = app(ItemHydrator::class);
 
     /** @var Funnel $funnel */
-    $funnel = $hydrator->hydrate(new Funnel(), [
+    $funnel = $hydrator->hydrate(new Funnel, [
         Funnel::ACTIVE => true,
         Funnel::PERCENT => 100,
         Funnel::RULES => [],
@@ -25,7 +25,7 @@ it('has metrics as a relation', function () {
     $hydrator = app(ItemHydrator::class);
 
     /** @var Funnel $funnel */
-    $funnel = $hydrator->hydrate(new Funnel(), [
+    $funnel = $hydrator->hydrate(new Funnel, [
         Funnel::ACTIVE => true,
         Funnel::PERCENT => 100,
         Funnel::RULES => [],

--- a/tests/Jobs/RecordMetricForEnteredFunnelJobTest.php
+++ b/tests/Jobs/RecordMetricForEnteredFunnelJobTest.php
@@ -10,7 +10,7 @@ use Swis\JsonApi\Client\ItemHydrator;
 
 it('records the metric for an entered funnel', function () {
     $hydrator = $this->app->make(ItemHydrator::class);
-    $funnel = $hydrator->hydrate(new Funnel(), [
+    $funnel = $hydrator->hydrate(new Funnel, [
         'featureSets' => [
             [
                 'id' => '5678',
@@ -36,7 +36,7 @@ it('records the metric for an entered funnel', function () {
 
 it('skips recording the metric if it is not tracked in the funnel', function () {
     $hydrator = $this->app->make(ItemHydrator::class);
-    $funnel = $hydrator->hydrate(new Funnel(), [
+    $funnel = $hydrator->hydrate(new Funnel, [
         'featureSets' => [
             [
                 'id' => '5678',

--- a/tests/Pennant/Concerns/StoresFlagPalFeaturesInDatabaseTest.php
+++ b/tests/Pennant/Concerns/StoresFlagPalFeaturesInDatabaseTest.php
@@ -1,0 +1,177 @@
+<?php
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Laravel\Pennant\Drivers\DatabaseDriver;
+use Laravel\Pennant\Feature;
+use Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures as StoresFlagPalFeaturesContract;
+use Rapkis\FlagPal\Pennant\Concerns\StoresFlagPalFeaturesInDatabase;
+use Rapkis\FlagPal\Pennant\StatelessFeatures;
+
+it('gets features from database', function () {
+    $builder = $this->createMock(Builder::class);
+    $collection = collect([
+        'feature1' => json_encode('value1'),
+        'feature2' => json_encode(['nested' => 'value']),
+    ]);
+
+    $builder->expects($this->once())
+        ->method('where')
+        ->with('scope', 'test-scope')
+        ->willReturnSelf();
+
+    $builder->expects($this->once())
+        ->method('pluck')
+        ->with('value', 'name')
+        ->willReturn($collection);
+
+    DB::shouldReceive('connection')
+        ->once()
+        ->with(null)
+        ->andReturnSelf();
+
+    DB::shouldReceive('table')
+        ->once()
+        ->with('features')
+        ->andReturn($builder);
+
+    $model = new class implements StoresFlagPalFeaturesContract {
+        use StoresFlagPalFeaturesInDatabase;
+
+        public function __toString() {
+            return 'test-model';
+        }
+    };
+
+    // Mock the Feature::serializeScope method
+    Feature::shouldReceive('serializeScope')
+        ->once()
+        ->with($model)
+        ->andReturn('test-scope');
+
+    $features = $model->getFlagPalFeatures();
+
+    expect($features)->toBeInstanceOf(StatelessFeatures::class)
+        ->and($features->features)->toBe([
+            'feature1' => 'value1',
+            'feature2' => ['nested' => 'value'],
+        ]);
+});
+
+it('caches features after first retrieval', function () {
+    $builder = $this->createMock(Builder::class);
+    $collection = collect([
+        'feature1' => json_encode('value1'),
+    ]);
+
+    $builder->expects($this->once())
+        ->method('where')
+        ->with('scope', 'test-scope')
+        ->willReturnSelf();
+
+    $builder->expects($this->once())
+        ->method('pluck')
+        ->with('value', 'name')
+        ->willReturn($collection);
+
+    DB::shouldReceive('connection')
+        ->once()
+        ->with(null)
+        ->andReturnSelf();
+
+    DB::shouldReceive('table')
+        ->once()
+        ->with('features')
+        ->andReturn($builder);
+
+    $model = new class implements StoresFlagPalFeaturesContract {
+        use StoresFlagPalFeaturesInDatabase;
+
+        public function __toString() {
+            return 'test-model';
+        }
+    };
+
+    // Mock the Feature::serializeScope method
+    Feature::shouldReceive('serializeScope')
+        ->once()
+        ->with($model)
+        ->andReturn('test-scope');
+
+    // First call should hit the database
+    $features1 = $model->getFlagPalFeatures();
+
+    // Second call should use cached value
+    $features2 = $model->getFlagPalFeatures();
+
+    expect($features1)->toBe($features2);
+});
+
+it('saves features to database', function () {
+    $builder = $this->createMock(Builder::class);
+    $collection = collect([
+        'feature1' => json_encode('old-value'),
+        'feature2' => json_encode('value2'),
+    ]);
+
+    // For getFlagPalFeatures and other operations
+    $builder->expects($this->exactly(3))
+        ->method('where')
+        ->with('scope', 'test-scope')
+        ->willReturnSelf();
+
+    $builder->expects($this->once())
+        ->method('pluck')
+        ->with('value', 'name')
+        ->willReturn($collection);
+
+    // For delete
+    $builder->expects($this->once())
+        ->method('whereIn')
+        ->with('name', ['feature2'])
+        ->willReturnSelf();
+
+    $builder->expects($this->once())
+        ->method('delete');
+
+    // For upsert
+    $builder->expects($this->once())
+        ->method('upsert')
+        ->with($this->callback(function ($items) {
+            return count($items) === 1
+                && $items[0]['name'] === 'feature1'
+                && $items[0]['scope'] === 'test-scope'
+                && json_decode($items[0]['value']) === 'new-value';
+        }), ['name', 'scope'], ['value', DatabaseDriver::UPDATED_AT]);
+
+    DB::shouldReceive('connection')
+        ->times(3)
+        ->with(null)
+        ->andReturnSelf();
+
+    DB::shouldReceive('table')
+        ->times(3)
+        ->with('features')
+        ->andReturn($builder);
+
+    $model = new class implements StoresFlagPalFeaturesContract {
+        use StoresFlagPalFeaturesInDatabase;
+
+        public function __toString() {
+            return 'test-model';
+        }
+    };
+
+    // Mock the Feature::serializeScope method
+    Feature::shouldReceive('serializeScope')
+        ->times(4)
+        ->with($model)
+        ->andReturn('test-scope');
+
+    $result = $model->saveFlagPalFeatures([
+        'feature1' => 'new-value',
+        'feature2' => null, // This should be deleted
+    ]);
+
+    expect($result)->toBe($model);
+});

--- a/tests/Pennant/Concerns/StoresFlagPalFeaturesInDatabaseTest.php
+++ b/tests/Pennant/Concerns/StoresFlagPalFeaturesInDatabaseTest.php
@@ -35,10 +35,12 @@ it('gets features from database', function () {
         ->with('features')
         ->andReturn($builder);
 
-    $model = new class implements StoresFlagPalFeaturesContract {
+    $model = new class implements StoresFlagPalFeaturesContract
+    {
         use StoresFlagPalFeaturesInDatabase;
 
-        public function __toString() {
+        public function __toString()
+        {
             return 'test-model';
         }
     };
@@ -84,10 +86,12 @@ it('caches features after first retrieval', function () {
         ->with('features')
         ->andReturn($builder);
 
-    $model = new class implements StoresFlagPalFeaturesContract {
+    $model = new class implements StoresFlagPalFeaturesContract
+    {
         use StoresFlagPalFeaturesInDatabase;
 
-        public function __toString() {
+        public function __toString()
+        {
             return 'test-model';
         }
     };
@@ -154,10 +158,12 @@ it('saves features to database', function () {
         ->with('features')
         ->andReturn($builder);
 
-    $model = new class implements StoresFlagPalFeaturesContract {
+    $model = new class implements StoresFlagPalFeaturesContract
+    {
         use StoresFlagPalFeaturesInDatabase;
 
-        public function __toString() {
+        public function __toString()
+        {
             return 'test-model';
         }
     };

--- a/tests/Pennant/Concerns/StoresFlagPalFeaturesTest.php
+++ b/tests/Pennant/Concerns/StoresFlagPalFeaturesTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures as StoresFlagPalFeaturesContract;
+use Rapkis\FlagPal\FlagPal;
+use Rapkis\FlagPal\Pennant\Concerns\StoresFlagPalFeatures;
+use Rapkis\FlagPal\Pennant\StatelessFeatures;
+use Rapkis\FlagPal\Resources\Actor;
+
+it('gets features from FlagPal actor', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+
+    $actor = new Actor();
+    $actor->features = ['feature1' => 'value1', 'feature2' => 'value2'];
+
+    $flagPal->expects($this->once())
+        ->method('getActor')
+        ->with('test-reference')
+        ->willReturn($actor);
+
+    $model = new class($flagPal) implements StoresFlagPalFeaturesContract {
+        use StoresFlagPalFeatures;
+
+        public function __construct(FlagPal $flagPal) {
+            $this->flagPal = $flagPal;
+        }
+
+        public function getFlagPalReference(): string {
+            return 'test-reference';
+        }
+    };
+
+    $features = $model->getFlagPalFeatures();
+
+    expect($features)->toBeInstanceOf(StatelessFeatures::class)
+        ->and($features->features)->toBe(['feature1' => 'value1', 'feature2' => 'value2']);
+});
+
+it('saves features to FlagPal actor', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+
+    $flagPal->expects($this->once())
+        ->method('saveActorFeatures')
+        ->with('test-reference', ['feature1' => 'new-value', 'feature2' => 'value2']);
+
+    $model = new class($flagPal) implements StoresFlagPalFeaturesContract {
+        use StoresFlagPalFeatures;
+
+        public function __construct(FlagPal $flagPal) {
+            $this->flagPal = $flagPal;
+        }
+
+        public function getFlagPalReference(): string {
+            return 'test-reference';
+        }
+    };
+
+    $result = $model->saveFlagPalFeatures(['feature1' => 'new-value', 'feature2' => 'value2']);
+
+    expect($result)->toBe($model);
+});
+
+it('handles null actor response', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+
+    $flagPal->expects($this->once())
+        ->method('getActor')
+        ->with('test-reference')
+        ->willReturn(null);
+
+    $model = new class($flagPal) implements StoresFlagPalFeaturesContract {
+        use StoresFlagPalFeatures;
+
+        public function __construct(FlagPal $flagPal) {
+            $this->flagPal = $flagPal;
+        }
+
+        public function getFlagPalReference(): string {
+            return 'test-reference';
+        }
+    };
+
+    expect($model->getFlagPalFeatures())->toEqual(new StatelessFeatures([]));
+});

--- a/tests/Pennant/Concerns/StoresFlagPalFeaturesTest.php
+++ b/tests/Pennant/Concerns/StoresFlagPalFeaturesTest.php
@@ -9,7 +9,7 @@ use Rapkis\FlagPal\Resources\Actor;
 it('gets features from FlagPal actor', function () {
     $flagPal = $this->createMock(FlagPal::class);
 
-    $actor = new Actor();
+    $actor = new Actor;
     $actor->features = ['feature1' => 'value1', 'feature2' => 'value2'];
 
     $flagPal->expects($this->once())
@@ -17,14 +17,17 @@ it('gets features from FlagPal actor', function () {
         ->with('test-reference')
         ->willReturn($actor);
 
-    $model = new class($flagPal) implements StoresFlagPalFeaturesContract {
+    $model = new class($flagPal) implements StoresFlagPalFeaturesContract
+    {
         use StoresFlagPalFeatures;
 
-        public function __construct(FlagPal $flagPal) {
+        public function __construct(FlagPal $flagPal)
+        {
             $this->flagPal = $flagPal;
         }
 
-        public function getFlagPalReference(): string {
+        public function getFlagPalReference(): string
+        {
             return 'test-reference';
         }
     };
@@ -42,14 +45,17 @@ it('saves features to FlagPal actor', function () {
         ->method('saveActorFeatures')
         ->with('test-reference', ['feature1' => 'new-value', 'feature2' => 'value2']);
 
-    $model = new class($flagPal) implements StoresFlagPalFeaturesContract {
+    $model = new class($flagPal) implements StoresFlagPalFeaturesContract
+    {
         use StoresFlagPalFeatures;
 
-        public function __construct(FlagPal $flagPal) {
+        public function __construct(FlagPal $flagPal)
+        {
             $this->flagPal = $flagPal;
         }
 
-        public function getFlagPalReference(): string {
+        public function getFlagPalReference(): string
+        {
             return 'test-reference';
         }
     };
@@ -67,14 +73,17 @@ it('handles null actor response', function () {
         ->with('test-reference')
         ->willReturn(null);
 
-    $model = new class($flagPal) implements StoresFlagPalFeaturesContract {
+    $model = new class($flagPal) implements StoresFlagPalFeaturesContract
+    {
         use StoresFlagPalFeatures;
 
-        public function __construct(FlagPal $flagPal) {
+        public function __construct(FlagPal $flagPal)
+        {
             $this->flagPal = $flagPal;
         }
 
-        public function getFlagPalReference(): string {
+        public function getFlagPalReference(): string
+        {
             return 'test-reference';
         }
     };

--- a/tests/Pennant/FlagPalDriverTest.php
+++ b/tests/Pennant/FlagPalDriverTest.php
@@ -1,18 +1,10 @@
 <?php
 
-use Illuminate\Support\Collection;
 use Laravel\Pennant\Contracts\FeatureScopeSerializeable;
-use Laravel\Pennant\Feature;
 use Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures;
 use Rapkis\FlagPal\FlagPal;
 use Rapkis\FlagPal\Pennant\FlagPalDriver;
-use Rapkis\FlagPal\Pennant\HasFlagPalReference;
 use Rapkis\FlagPal\Pennant\StatelessFeatures;
-use Rapkis\FlagPal\Resources\Actor;
-use Rapkis\FlagPal\Resources\FeatureSet;
-use Rapkis\FlagPal\Resources\Funnel;
-use Swis\JsonApi\Client\Document;
-use Swis\JsonApi\Client\ItemHydrator;
 
 it('returns entered funnels from FlagPal', function () {
     $flagPal = $this->createMock(FlagPal::class);
@@ -62,22 +54,28 @@ it('gets all features for multiple scopes', function () {
 
     $driver = new FlagPalDriver($flagPal);
 
-    $scope1 = new class implements FeatureScopeSerializeable {
-        public function __toString() {
+    $scope1 = new class implements FeatureScopeSerializeable
+    {
+        public function __toString()
+        {
             return 'scope1';
         }
 
-        public function featureScopeSerialize(): string {
+        public function featureScopeSerialize(): string
+        {
             return 'scope1';
         }
     };
 
-    $scope2 = new class implements FeatureScopeSerializeable {
-        public function __toString() {
+    $scope2 = new class implements FeatureScopeSerializeable
+    {
+        public function __toString()
+        {
             return 'scope2';
         }
 
-        public function featureScopeSerialize(): string {
+        public function featureScopeSerialize(): string
+        {
             return 'scope2';
         }
     };
@@ -131,16 +129,20 @@ it('gets feature value for scope implementing StoresFlagPalFeatures', function (
 
     $driver = new FlagPalDriver($flagPal);
 
-    $scope = new class implements StoresFlagPalFeatures, FeatureScopeSerializeable {
-        public function getFlagPalFeatures(): StatelessFeatures {
+    $scope = new class implements FeatureScopeSerializeable, StoresFlagPalFeatures
+    {
+        public function getFlagPalFeatures(): StatelessFeatures
+        {
             return new StatelessFeatures(['feature1' => 'stored']);
         }
 
-        public function saveFlagPalFeatures(array $features): \Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures {
+        public function saveFlagPalFeatures(array $features): \Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures
+        {
             return $this;
         }
 
-        public function featureScopeSerialize(): string {
+        public function featureScopeSerialize(): string
+        {
             return 'stored-features-scope';
         }
     };
@@ -154,19 +156,24 @@ it('sets feature value for scope implementing StoresFlagPalFeatures', function (
     $flagPal = $this->createMock(FlagPal::class);
     $driver = new FlagPalDriver($flagPal);
 
-    $scope = new class implements StoresFlagPalFeatures, FeatureScopeSerializeable {
+    $scope = new class implements FeatureScopeSerializeable, StoresFlagPalFeatures
+    {
         public $savedFeatures = [];
 
-        public function getFlagPalFeatures(): StatelessFeatures {
+        public function getFlagPalFeatures(): StatelessFeatures
+        {
             return new StatelessFeatures([]);
         }
 
-        public function saveFlagPalFeatures(array $features): \Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures {
+        public function saveFlagPalFeatures(array $features): \Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures
+        {
             $this->savedFeatures = $features;
+
             return $this;
         }
 
-        public function featureScopeSerialize(): string {
+        public function featureScopeSerialize(): string
+        {
             return 'save-features-scope';
         }
     };
@@ -188,20 +195,26 @@ it('deletes feature for scope implementing StoresFlagPalFeatures', function () {
     $flagPal = $this->createMock(FlagPal::class);
     $driver = new FlagPalDriver($flagPal);
 
-    $scope = new class implements StoresFlagPalFeatures, FeatureScopeSerializeable {
+    $scope = new class implements FeatureScopeSerializeable, StoresFlagPalFeatures
+    {
         public $savedFeatures = [];
+
         private $features = ['feature1' => 'value', 'feature2' => 'value2'];
 
-        public function getFlagPalFeatures(): StatelessFeatures {
+        public function getFlagPalFeatures(): StatelessFeatures
+        {
             return new StatelessFeatures($this->features);
         }
 
-        public function saveFlagPalFeatures(array $features): \Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures {
+        public function saveFlagPalFeatures(array $features): \Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures
+        {
             $this->savedFeatures = $features;
+
             return $this;
         }
 
-        public function featureScopeSerialize(): string {
+        public function featureScopeSerialize(): string
+        {
             return 'delete-features-scope';
         }
     };

--- a/tests/Pennant/FlagPalDriverTest.php
+++ b/tests/Pennant/FlagPalDriverTest.php
@@ -1,0 +1,257 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Laravel\Pennant\Contracts\FeatureScopeSerializeable;
+use Laravel\Pennant\Feature;
+use Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures;
+use Rapkis\FlagPal\FlagPal;
+use Rapkis\FlagPal\Pennant\FlagPalDriver;
+use Rapkis\FlagPal\Pennant\HasFlagPalReference;
+use Rapkis\FlagPal\Pennant\StatelessFeatures;
+use Rapkis\FlagPal\Resources\Actor;
+use Rapkis\FlagPal\Resources\FeatureSet;
+use Rapkis\FlagPal\Resources\Funnel;
+use Swis\JsonApi\Client\Document;
+use Swis\JsonApi\Client\ItemHydrator;
+
+it('returns entered funnels from FlagPal', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+    $flagPal->expects($this->once())
+        ->method('getEnteredFunnels')
+        ->willReturn(['funnel1' => 'data1', 'funnel2' => 'data2']);
+
+    $driver = new FlagPalDriver($flagPal);
+
+    expect($driver->getEnteredFunnels())->toBe(['funnel1' => 'data1', 'funnel2' => 'data2']);
+});
+
+it('throws exception when trying to define a feature', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+    $driver = new FlagPalDriver($flagPal);
+
+    expect(fn () => $driver->define('feature', fn () => true))
+        ->toThrow(Exception::class, 'FlagPal can only define features externally.');
+});
+
+it('returns defined features', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+    $flagPal->expects($this->once())
+        ->method('definedFeatures')
+        ->willReturn([
+            ['name' => 'feature1'],
+            ['name' => 'feature2'],
+        ]);
+
+    $driver = new FlagPalDriver($flagPal);
+
+    expect($driver->defined())->toBe(['feature1', 'feature2']);
+});
+
+it('gets all features for multiple scopes', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+    $flagPal->method('definedFeatures')
+        ->willReturn([
+            ['name' => 'feature1'],
+            ['name' => 'feature2'],
+        ]);
+
+    $flagPal->method('resolveFeatures')
+        ->willReturnCallback(function ($features) {
+            return $features + ['feature1' => 'value1', 'feature2' => 'value2'];
+        });
+
+    $driver = new FlagPalDriver($flagPal);
+
+    $scope1 = new class implements FeatureScopeSerializeable {
+        public function __toString() {
+            return 'scope1';
+        }
+
+        public function featureScopeSerialize(): string {
+            return 'scope1';
+        }
+    };
+
+    $scope2 = new class implements FeatureScopeSerializeable {
+        public function __toString() {
+            return 'scope2';
+        }
+
+        public function featureScopeSerialize(): string {
+            return 'scope2';
+        }
+    };
+
+    $result = $driver->getAll([
+        'feature1' => [$scope1, $scope2],
+        'feature2' => [$scope1],
+    ]);
+
+    expect($result)->toBeArray()
+        ->and($result['feature1'])->toBeArray()
+        ->and($result['feature2'])->toBeArray()
+        ->and($result['feature1'][0])->toBe('value1')
+        ->and($result['feature1'][1])->toBe('value1')
+        ->and($result['feature2'][0])->toBe('value2');
+});
+
+it('gets feature value for stateless features scope', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+    $flagPal->method('definedFeatures')
+        ->willReturn([
+            ['name' => 'feature1'],
+            ['name' => 'feature2'],
+        ]);
+
+    $flagPal->expects($this->once())
+        ->method('resolveFeatures')
+        ->with(['feature1' => 'initial'])
+        ->willReturn(['feature1' => 'resolved', 'feature2' => 'value2']);
+
+    $driver = new FlagPalDriver($flagPal);
+    $scope = new StatelessFeatures(['feature1' => 'initial']);
+
+    $result = $driver->get('feature1', $scope);
+
+    expect($result)->toBe('resolved');
+});
+
+it('gets feature value for scope implementing StoresFlagPalFeatures', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+    $flagPal->method('definedFeatures')
+        ->willReturn([
+            ['name' => 'feature1'],
+            ['name' => 'feature2'],
+        ]);
+
+    $flagPal->expects($this->once())
+        ->method('resolveFeatures')
+        ->with(['feature1' => 'stored'])
+        ->willReturn(['feature1' => 'resolved', 'feature2' => 'value2']);
+
+    $driver = new FlagPalDriver($flagPal);
+
+    $scope = new class implements StoresFlagPalFeatures, FeatureScopeSerializeable {
+        public function getFlagPalFeatures(): StatelessFeatures {
+            return new StatelessFeatures(['feature1' => 'stored']);
+        }
+
+        public function saveFlagPalFeatures(array $features): \Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures {
+            return $this;
+        }
+
+        public function featureScopeSerialize(): string {
+            return 'stored-features-scope';
+        }
+    };
+
+    $result = $driver->get('feature1', $scope);
+
+    expect($result)->toBe('resolved');
+});
+
+it('sets feature value for scope implementing StoresFlagPalFeatures', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+    $driver = new FlagPalDriver($flagPal);
+
+    $scope = new class implements StoresFlagPalFeatures, FeatureScopeSerializeable {
+        public $savedFeatures = [];
+
+        public function getFlagPalFeatures(): StatelessFeatures {
+            return new StatelessFeatures([]);
+        }
+
+        public function saveFlagPalFeatures(array $features): \Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures {
+            $this->savedFeatures = $features;
+            return $this;
+        }
+
+        public function featureScopeSerialize(): string {
+            return 'save-features-scope';
+        }
+    };
+
+    $driver->set('feature1', $scope, 'new-value');
+
+    expect($scope->savedFeatures)->toBe(['feature1' => 'new-value']);
+});
+
+it('throws exception when trying to set a feature for all scopes', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+    $driver = new FlagPalDriver($flagPal);
+
+    expect(fn () => $driver->setForAllScopes('feature', true))
+        ->toThrow(Exception::class, 'You can set a feature for all scopes by creating an Experience in FlagPal');
+});
+
+it('deletes feature for scope implementing StoresFlagPalFeatures', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+    $driver = new FlagPalDriver($flagPal);
+
+    $scope = new class implements StoresFlagPalFeatures, FeatureScopeSerializeable {
+        public $savedFeatures = [];
+        private $features = ['feature1' => 'value', 'feature2' => 'value2'];
+
+        public function getFlagPalFeatures(): StatelessFeatures {
+            return new StatelessFeatures($this->features);
+        }
+
+        public function saveFlagPalFeatures(array $features): \Rapkis\FlagPal\Contracts\Pennant\StoresFlagPalFeatures {
+            $this->savedFeatures = $features;
+            return $this;
+        }
+
+        public function featureScopeSerialize(): string {
+            return 'delete-features-scope';
+        }
+    };
+
+    $driver->delete('feature1', $scope);
+
+    expect($scope->savedFeatures)->toBe(['feature2' => 'value2']);
+});
+
+it('throws exception when trying to purge all features', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+    $driver = new FlagPalDriver($flagPal);
+
+    expect(fn () => $driver->purge(null))
+        ->toThrow(Exception::class, 'You can not purge FlagPal features! Remove them from FlagPal instead.');
+});
+
+it('throws exception when trying to purge specific features', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+    $driver = new FlagPalDriver($flagPal);
+
+    expect(fn () => $driver->purge(['feature1']))
+        ->toThrow(Exception::class, 'You can not purge FlagPal features! Remove them from FlagPal instead.');
+});
+
+it('returns false for undefined features', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+    $flagPal->method('definedFeatures')
+        ->willReturn([
+            ['name' => 'feature1'],
+            ['name' => 'feature2'],
+        ]);
+
+    $driver = new FlagPalDriver($flagPal);
+    $scope = new StatelessFeatures([]);
+
+    expect($driver->get('undefined-feature', $scope))->toBeFalse();
+});
+
+it('returns defined features for scope', function () {
+    $flagPal = $this->createMock(FlagPal::class);
+    $flagPal->expects($this->once())
+        ->method('definedFeatures')
+        ->willReturn([
+            ['name' => 'feature1'],
+            ['name' => 'feature2'],
+        ]);
+
+    $driver = new FlagPalDriver($flagPal);
+    $scope = new StatelessFeatures([]);
+
+    expect($driver->definedFeaturesForScope($scope))->toBe(['feature1', 'feature2']);
+});

--- a/tests/Pennant/HasFlagPalReferenceTest.php
+++ b/tests/Pennant/HasFlagPalReferenceTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use Laravel\Pennant\Contracts\FeatureScopeSerializeable;
+use Laravel\Pennant\Feature;
+use Rapkis\FlagPal\Pennant\HasFlagPalReference;
+
+it('returns serialized scope as reference', function () {
+    $model = new class implements FeatureScopeSerializeable {
+        use HasFlagPalReference;
+
+        public $id = 123;
+
+        public function __toString() {
+            return 'Model:123';
+        }
+
+        public function featureScopeSerialize(): string {
+            return 'Model:123';
+        }
+    };
+
+    $serialized = Feature::serializeScope($model);
+
+    expect($model->getFlagPalReference())->toBe($serialized);
+});
+
+it('can be used in different model types', function () {
+    $model1 = new class implements FeatureScopeSerializeable {
+        use HasFlagPalReference;
+
+        public $id = 123;
+
+        public function __toString() {
+            return 'Model1:123';
+        }
+
+        public function featureScopeSerialize(): string {
+            return 'Model1:123';
+        }
+    };
+
+    $model2 = new class implements FeatureScopeSerializeable {
+        use HasFlagPalReference;
+
+        public $id = 456;
+
+        public function __toString() {
+            return 'Model2:456';
+        }
+
+        public function featureScopeSerialize(): string {
+            return 'Model2:456';
+        }
+    };
+
+    expect($model1->getFlagPalReference())->not->toBe($model2->getFlagPalReference());
+});
+
+it('can be overridden in child classes', function () {
+    $model = new class implements FeatureScopeSerializeable {
+        use HasFlagPalReference;
+
+        public $id = 123;
+
+        public function getFlagPalReference(): string {
+            return 'custom-reference-' . $this->id;
+        }
+
+        public function featureScopeSerialize(): string {
+            return 'Model3:123';
+        }
+    };
+
+    expect($model->getFlagPalReference())->toBe('custom-reference-123');
+});

--- a/tests/Pennant/HasFlagPalReferenceTest.php
+++ b/tests/Pennant/HasFlagPalReferenceTest.php
@@ -5,16 +5,19 @@ use Laravel\Pennant\Feature;
 use Rapkis\FlagPal\Pennant\HasFlagPalReference;
 
 it('returns serialized scope as reference', function () {
-    $model = new class implements FeatureScopeSerializeable {
+    $model = new class implements FeatureScopeSerializeable
+    {
         use HasFlagPalReference;
 
         public $id = 123;
 
-        public function __toString() {
+        public function __toString()
+        {
             return 'Model:123';
         }
 
-        public function featureScopeSerialize(): string {
+        public function featureScopeSerialize(): string
+        {
             return 'Model:123';
         }
     };
@@ -25,30 +28,36 @@ it('returns serialized scope as reference', function () {
 });
 
 it('can be used in different model types', function () {
-    $model1 = new class implements FeatureScopeSerializeable {
+    $model1 = new class implements FeatureScopeSerializeable
+    {
         use HasFlagPalReference;
 
         public $id = 123;
 
-        public function __toString() {
+        public function __toString()
+        {
             return 'Model1:123';
         }
 
-        public function featureScopeSerialize(): string {
+        public function featureScopeSerialize(): string
+        {
             return 'Model1:123';
         }
     };
 
-    $model2 = new class implements FeatureScopeSerializeable {
+    $model2 = new class implements FeatureScopeSerializeable
+    {
         use HasFlagPalReference;
 
         public $id = 456;
 
-        public function __toString() {
+        public function __toString()
+        {
             return 'Model2:456';
         }
 
-        public function featureScopeSerialize(): string {
+        public function featureScopeSerialize(): string
+        {
             return 'Model2:456';
         }
     };
@@ -57,16 +66,19 @@ it('can be used in different model types', function () {
 });
 
 it('can be overridden in child classes', function () {
-    $model = new class implements FeatureScopeSerializeable {
+    $model = new class implements FeatureScopeSerializeable
+    {
         use HasFlagPalReference;
 
         public $id = 123;
 
-        public function getFlagPalReference(): string {
-            return 'custom-reference-' . $this->id;
+        public function getFlagPalReference(): string
+        {
+            return 'custom-reference-'.$this->id;
         }
 
-        public function featureScopeSerialize(): string {
+        public function featureScopeSerialize(): string
+        {
             return 'Model3:123';
         }
     };

--- a/tests/Pennant/StatelessFeaturesTest.php
+++ b/tests/Pennant/StatelessFeaturesTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Rapkis\FlagPal\Pennant\StatelessFeatures;
+
+it('stores features in a readonly property', function () {
+    $features = ['feature1' => 'value1', 'feature2' => 'value2'];
+    $statelessFeatures = new StatelessFeatures($features);
+
+    expect($statelessFeatures->features)->toBe($features);
+});
+
+it('serializes features to JSON', function () {
+    $features = ['feature1' => 'value1', 'feature2' => 'value2'];
+    $statelessFeatures = new StatelessFeatures($features);
+
+    expect($statelessFeatures->featureScopeSerialize())->toBe(json_encode($features));
+});
+
+it('handles empty features array', function () {
+    $statelessFeatures = new StatelessFeatures([]);
+
+    expect($statelessFeatures->features)->toBe([])
+        ->and($statelessFeatures->featureScopeSerialize())->toBe('[]');
+});
+
+it('handles complex nested data structures', function () {
+    $features = [
+        'feature1' => 'value1',
+        'feature2' => ['nested' => 'value', 'array' => [1, 2, 3]],
+        'feature3' => (object) ['property' => 'value'],
+    ];
+    $statelessFeatures = new StatelessFeatures($features);
+
+    expect($statelessFeatures->featureScopeSerialize())->toBe(json_encode($features));
+});

--- a/tests/Support/RaffleTest.php
+++ b/tests/Support/RaffleTest.php
@@ -3,25 +3,25 @@
 use Rapkis\FlagPal\Support\Raffle;
 
 test('can draw a winner', function () {
-    $raffle = new Raffle();
+    $raffle = new Raffle;
 
     expect($raffle->draw(['contestant' => 1]))->toBe('contestant');
 });
 
 test('can force a winner', function () {
-    $raffle = new Raffle();
+    $raffle = new Raffle;
     $raffle->alwaysDraw('winner');
 
     expect($raffle->draw(['contestant' => 1]))->toBe('winner');
 });
 
 test('validates empty pool', function () {
-    $raffle = new Raffle();
+    $raffle = new Raffle;
     $raffle->draw([]);
 })->throws(InvalidArgumentException::class, 'The raffle pool must not be empty');
 
 test('validates weights', function (array $contestants) {
-    $raffle = new Raffle();
+    $raffle = new Raffle;
 
     $raffle->draw($contestants);
 })->throws(InvalidArgumentException::class, 'All weights must always be a positive integer')

--- a/tests/Validation/RuleFactoryTest.php
+++ b/tests/Validation/RuleFactoryTest.php
@@ -4,12 +4,12 @@ use Rapkis\FlagPal\Validation\RuleFactory;
 use Rapkis\FlagPal\Validation\Rules\DateBeforeOrEqualRule;
 
 it('can make a rule', function () {
-    $factory = new RuleFactory();
+    $factory = new RuleFactory;
     expect($factory->make('date_before_or_equal'))->toBeInstanceOf(DateBeforeOrEqualRule::class);
 });
 
 it('throws exception if rule class does not exist', function () {
-    $factory = new RuleFactory();
+    $factory = new RuleFactory;
 
     $this->expectException(InvalidArgumentException::class);
     $this->expectExceptionMessage('Rule "does not exist" does not exist');


### PR DESCRIPTION
This change adds comprehensive integration with Laravel Pennant, allowing FlagPal to be used as a feature flag driver within Laravel's native feature flag system.
This integration allows developers to use FlagPal easier, providing a consistent experience while leveraging FlagPal's remote configuration capabilities.

Main Changes:
- FlagPal Driver for Pennant: Created a custom driver (`FlagPalDriver`) that implements Laravel Pennant's `Driver` and `DefinesFeaturesExternally` interfaces, enabling seamless integration with Laravel's feature flag system.
- Added `StatelessFeatures` class for in-memory feature storage
- Implemented `StoresFlagPalFeatures` interface and trait for models that need to store feature flags
- Created `StoresFlagPalFeaturesInDatabase` trait for database-backed feature storage
- Added `HasFlagPalReference` trait to allow models to be identified as feature flag actors, and their features be saved in FlagPal. The default reference serialization is compatible with Laravel Pennant's scope system
- Modified `FlagPalServiceProvider` to register the Pennant driver(s)
- Added configuration options for Pennant integration
- Added tests for all new components
- Ensured compatibility with Laravel Pennant's expected behavior
- Added relevant information about Pennant in README.md