### PR TITLE
Memoize definedFeatures and getFunnels per project

### DIFF
--- a/src/FlagPal.php
+++ b/src/FlagPal.php
@@ -36,7 +36,11 @@ class FlagPal
 
     private int $cacheTtlSeconds;
 
-    private ?Collection $funnels = null;
+    /** @var array<string, Collection> */
+    private array $funnels = [];
+
+    /** @var array<string, array> */
+    private array $definedFeatures = [];
 
     public function __construct(
         protected readonly FunnelRepository $funnelRepository,
@@ -55,6 +59,11 @@ class FlagPal
     }
 
     public function definedFeatures(): array
+    {
+        return $this->definedFeatures[$this->project] ??= $this->loadDefinedFeatures();
+    }
+
+    protected function loadDefinedFeatures(): array
     {
         $cacheKey = "flagpal-features-{$this->project}";
 
@@ -165,7 +174,29 @@ class FlagPal
 
     public function getFunnels(): Collection
     {
-        return $this->funnels ?? ($this->funnels = $this->loadFunnels());
+        return $this->funnels[$this->project] ??= $this->loadFunnels();
+    }
+
+    public function forgetDefinedFeaturesCache(?string $project = null): void
+    {
+        if ($project === null) {
+            $this->definedFeatures = [];
+
+            return;
+        }
+
+        unset($this->definedFeatures[$project]);
+    }
+
+    public function forgetFunnelsCache(?string $project = null): void
+    {
+        if ($project === null) {
+            $this->funnels = [];
+
+            return;
+        }
+
+        unset($this->funnels[$project]);
     }
 
     protected function loadFunnels(): Collection

--- a/tests/FlagPalTest.php
+++ b/tests/FlagPalTest.php
@@ -617,6 +617,161 @@ it('excludes undefined features from cast and logs error', function (?string $lo
     [null],
 ]);
 
+it('memoizes definedFeatures per project within a single instance', function () {
+    config(['flagpal.cache.driver' => 'array']);
+
+    $featureRepository = $this->createMock(FeatureRepository::class);
+
+    /** @var FlagPal $flagPal */
+    $flagPal = $this->app->make(FlagPal::class, ['featureRepository' => $featureRepository]);
+
+    $document = $this->createStub(DocumentInterface::class);
+    $document->method('getData')->willReturn(new Collection([
+        ['name' => 'feature1', 'kind' => 'string'],
+    ]));
+
+    // Repository hit once — memoization must satisfy subsequent calls even after the cache store is flushed.
+    $featureRepository->expects($this->once())
+        ->method('all')
+        ->willReturn($document);
+
+    $flagPal->definedFeatures();
+
+    app(CacheManager::class)->driver()->flush();
+
+    $flagPal->definedFeatures();
+    $flagPal->definedFeatures();
+});
+
+it('memoizes getFunnels per project so asProject switches refetch', function () {
+    config([
+        'flagpal.default_project' => 'a',
+        'flagpal.projects' => [
+            'a' => ['name' => 'a', 'bearer_token' => 'a-token'],
+            'b' => ['name' => 'b', 'bearer_token' => 'b-token'],
+        ],
+    ]);
+
+    $funnelRepository = $this->createMock(FunnelRepository::class);
+    $featureRepository = $this->createStub(FeatureRepository::class);
+
+    /** @var FlagPal $flagPal */
+    $flagPal = $this->app->make(FlagPal::class, [
+        'funnelRepository' => $funnelRepository,
+        'featureRepository' => $featureRepository,
+    ]);
+
+    $document = $this->createStub(DocumentInterface::class);
+    $document->method('getData')->willReturn(new Collection);
+    $featureRepository->method('all')->willReturn((new Document)->setData(new Collection));
+
+    $funnelRepository->expects($this->exactly(2))
+        ->method('all')
+        ->willReturn($document);
+
+    // project a — first load hits repo
+    $flagPal->getFunnels();
+    // project a — second load served from instance cache
+    $flagPal->getFunnels();
+
+    $flagPal->asProject('b');
+
+    // project b — new entry, hits repo
+    $flagPal->getFunnels();
+    // project b — served from instance cache
+    $flagPal->getFunnels();
+
+    $flagPal->asProject('a');
+
+    // project a — still memoized from earlier, no third repo call
+    $flagPal->getFunnels();
+});
+
+it('forgetDefinedFeaturesCache clears memoized defined features', function () {
+    config(['flagpal.cache.driver' => 'array']);
+
+    $featureRepository = $this->createMock(FeatureRepository::class);
+
+    /** @var FlagPal $flagPal */
+    $flagPal = $this->app->make(FlagPal::class, ['featureRepository' => $featureRepository]);
+
+    $document = $this->createStub(DocumentInterface::class);
+    $document->method('getData')->willReturn(new Collection([
+        ['name' => 'feature1', 'kind' => 'string'],
+    ]));
+
+    $featureRepository->expects($this->exactly(2))
+        ->method('all')
+        ->willReturn($document);
+
+    $flagPal->definedFeatures();
+
+    app(CacheManager::class)->driver()->flush();
+    $flagPal->forgetDefinedFeaturesCache();
+
+    $flagPal->definedFeatures();
+});
+
+it('forgetFunnelsCache clears memoized funnels', function () {
+    $funnelRepository = $this->createMock(FunnelRepository::class);
+    $featureRepository = $this->createStub(FeatureRepository::class);
+
+    /** @var FlagPal $flagPal */
+    $flagPal = $this->app->make(FlagPal::class, [
+        'funnelRepository' => $funnelRepository,
+        'featureRepository' => $featureRepository,
+    ]);
+
+    $document = $this->createStub(DocumentInterface::class);
+    $document->method('getData')->willReturn(new Collection);
+    $featureRepository->method('all')->willReturn((new Document)->setData(new Collection));
+
+    $funnelRepository->expects($this->exactly(2))
+        ->method('all')
+        ->willReturn($document);
+
+    $flagPal->getFunnels();
+
+    app(CacheManager::class)->driver()->flush();
+    $flagPal->forgetFunnelsCache();
+
+    $flagPal->getFunnels();
+});
+
+it('forgetDefinedFeaturesCache can target a single project', function () {
+    config([
+        'flagpal.default_project' => 'a',
+        'flagpal.projects' => [
+            'a' => ['name' => 'a', 'bearer_token' => 'a-token'],
+            'b' => ['name' => 'b', 'bearer_token' => 'b-token'],
+        ],
+    ]);
+
+    $featureRepository = $this->createMock(FeatureRepository::class);
+
+    /** @var FlagPal $flagPal */
+    $flagPal = $this->app->make(FlagPal::class, ['featureRepository' => $featureRepository]);
+
+    $document = $this->createStub(DocumentInterface::class);
+    $document->method('getData')->willReturn(new Collection);
+
+    // a warms once, b warms once, a re-fetched after targeted forget = 3 total.
+    $featureRepository->expects($this->exactly(3))
+        ->method('all')
+        ->willReturn($document);
+
+    $flagPal->asProject('a')->definedFeatures();
+    $flagPal->asProject('b')->definedFeatures();
+
+    app(CacheManager::class)->driver()->flush();
+    $flagPal->forgetDefinedFeaturesCache('a');
+
+    // 'b' still memoized — no new repo call
+    $flagPal->asProject('b')->definedFeatures();
+    // 'a' cleared — repo called again
+    $flagPal->asProject('a')->definedFeatures();
+});
+
 it('filters invalid features by their own rules', function () {
     /** @var CacheManager $cache */
     $cache = app(CacheManager::class);


### PR DESCRIPTION
## Summary
- Memoize `definedFeatures()` and `getFunnels()` per project on the `FlagPal` instance so repeat calls within a request (including after `asProject()` switches) reuse the already-loaded data instead of re-reading the cache store / repository.
- Add `forgetDefinedFeaturesCache(?string $project)` and `forgetFunnelsCache(?string $project)` helpers to invalidate the in-memory cache fully or for a single project.

## Test plan
- [x] `composer test` — new Pest tests cover per-project memoization, `asProject()` switching, and targeted/global forget helpers.